### PR TITLE
Fix issue to save xml body request

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -54,7 +54,7 @@ module.exports = function(configuration, args) {
 
         sendRequest(service, req, (result, httpCode) => {
           res.status(httpCode).send(result)
-          cacheDB.write(requestIdentifier, httpCode, result, saveRequest && Object.keys(req.body) != 0 ? JSON.parse(req.body) : null)
+          cacheDB.write(requestIdentifier, httpCode, result, saveRequest && req.body.length > 0)
         })
       })
     })


### PR DESCRIPTION
- Fix to save xml request body when using as Content-type due to be not
  a json format the JSON.parser() throws an exception and once the
  function have been used just to check if the request is to be
  persisted on cache DB there is no side-effect to change the logic
  around that.